### PR TITLE
Dynamic return for PLL_Model->get_languages_list()

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -4,7 +4,7 @@ services:
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 	-
-		class: WPSyntex\Polylang\PHPStan\PLLModelgetLanguagesListDynamicMethodReturnTypeExtension
+		class: WPSyntex\Polylang\PHPStan\PLLModelGetLanguagesListDynamicMethodReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 

--- a/extension.neon
+++ b/extension.neon
@@ -3,6 +3,10 @@ services:
 		class: WPSyntex\Polylang\PHPStan\LanguageReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
+	-
+		class: WPSyntex\Polylang\PHPStan\PLLModelgetLanguagesListDynamicMethodReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
 
 includes:
 	- ../../szepeviktor/phpstan-wordpress/extension.neon

--- a/src/PLLModelGetLanguagesListDynamicMethodReturnTypeExtension.php
+++ b/src/PLLModelGetLanguagesListDynamicMethodReturnTypeExtension.php
@@ -45,7 +45,7 @@ class PLLModelGetLanguagesListDynamicMethodReturnTypeExtension implements Dynami
 		$argumentType = $scope->getType( $args[0]->value );
 
 		// Called with an argument that is not an array.
-		if ( ! $argumentType instanceof ConstantArrayType ) {
+		if ( ! $argumentType->isArray()->yes() ) {
 			return new ArrayType( new IntegerType(), new ObjectType( PLL_Language::class ) );
 		}
 

--- a/src/PLLModelGetLanguagesListDynamicMethodReturnTypeExtension.php
+++ b/src/PLLModelGetLanguagesListDynamicMethodReturnTypeExtension.php
@@ -17,6 +17,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
@@ -93,7 +94,7 @@ class PLLModelGetLanguagesListDynamicMethodReturnTypeExtension implements Dynami
 
 		if ( empty( $fieldsValue ) ) {
 			// Without 'fields' argument, or empty value.
-			return new ArrayType( new IntegerType(), new ObjectType( PLL_Language::class ) );
+			return new ArrayType( new IntegerType(), new MixedType() );
 		}
 
 		switch ( $fieldsValue ) {

--- a/src/PLLModelGetLanguagesListDynamicMethodReturnTypeExtension.php
+++ b/src/PLLModelGetLanguagesListDynamicMethodReturnTypeExtension.php
@@ -25,7 +25,7 @@ use PHPStan\Type\UnionType;
 use PLL_Language;
 use PLL_Model;
 
-class PLLModelgetLanguagesListDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension {
+class PLLModelGetLanguagesListDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension {
 	public function getClass(): string {
 		return PLL_Model::class;
 	}

--- a/src/PLLModelGetLanguagesListDynamicMethodReturnTypeExtension.php
+++ b/src/PLLModelGetLanguagesListDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Set return type of PLL_Model->get_languages_list().
+ */
+
+declare(strict_types=1);
+
+namespace WPSyntex\Polylang\PHPStan;
+
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use PLL_Language;
+use PLL_Model;
+
+class PLLModelgetLanguagesListDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension {
+	public function getClass(): string {
+		return PLL_Model::class;
+	}
+
+	public function isMethodSupported( MethodReflection $methodReflection ): bool {
+		return $methodReflection->getName() === 'get_languages_list';
+	}
+
+	public function getTypeFromMethodCall( MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope ): Type {
+		$args = $methodCall->getArgs();
+
+		// Called without arguments.
+		if ( count( $args ) === 0 ) {
+			return new ArrayType( new IntegerType(), new ObjectType( PLL_Language::class ) );
+		}
+
+		$argumentType = $scope->getType( $args[0]->value );
+
+		// Called with an argument that is not an array.
+		if ( ! $argumentType instanceof ConstantArrayType ) {
+			return new ArrayType( new IntegerType(), new ObjectType( PLL_Language::class ) );
+		}
+
+		foreach ( $argumentType->getKeyTypes() as $index => $key ) {
+			if ( ! $key instanceof ConstantStringType || $key->getValue() !== 'fields' ) {
+				continue;
+			}
+
+			$fieldsType = $argumentType->getValueTypes()[ $index ];
+
+			if ( ! $fieldsType instanceof ConstantStringType ) {
+				return new ArrayType( new IntegerType(), new ObjectType( PLL_Language::class ) );
+			}
+
+			$fields = $fieldsType->getValue();
+			break;
+		}
+
+		// Without 'fields' argument, or empty value.
+		if ( empty( $fields ) ) {
+			return new ArrayType( new IntegerType(), new ObjectType( PLL_Language::class ) );
+		}
+
+		switch ( $fields ) {
+			case 'term_id':
+			case 'term_group':
+			case 'term_taxonomy_id':
+			case 'count':
+			case 'tl_term_id':
+			case 'tl_term_taxonomy_id':
+			case 'tl_count':
+			case 'is_rtl':
+			case 'mo_id':
+				return new ArrayType( new IntegerType(), new IntegerType() );
+			case 'name':
+			case 'slug':
+			case 'locale':
+			case 'w3c':
+			case 'flag_code':
+				return new ArrayType( new IntegerType(), new StringType() );
+			case 'page_on_front':
+			case 'page_for_posts':
+				return new ArrayType( new IntegerType(), new UnionType( [ new IntegerType(), new NullType() ] ) );
+			case 'facebook':
+			case 'home_ur':
+			case 'search_url':
+			case 'host':
+			case 'flag_url':
+			case 'flag':
+			case 'custom_flag_url':
+			case 'custom_flag':
+				return new ArrayType( new IntegerType(), new UnionType( [ new StringType(), new NullType() ] ) );
+			default:
+				// Everything exploded.
+				return new NullType();
+		}
+	}
+}


### PR DESCRIPTION
Related to https://github.com/polylang/polylang-pro/issues/1314.

This introduces a dynamic return type extension for `PLL_Model->get_languages_list()`. This is required because of the `fields` argument of the method: either it returns a list of `PLL_Language` instances, or a list of `PLL_Language` property values (`string|int|null`).

Ideally I wanted to get the types of all the `PLL_Language` public properties to know what to return at the end of `getTypeFromMethodCall()`, but since I am not familiar with PHPStan extensions, the properties are listed instead in a `switch`.

The final `return new NullType();` happens when `fields` does not correspond to a `PLL_Language` property: in this case `wp_list_pluck()` will trigger a php notice and return `null`.