### PR TITLE
Fix pll_the_languages() tests

### DIFF
--- a/src/GuessTypeFromSwitcherAttributes.php
+++ b/src/GuessTypeFromSwitcherAttributes.php
@@ -4,6 +4,7 @@ namespace WPSyntex\Polylang\PHPStan;
 
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Arg;
 use PHPStan\Analyser\Scope;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Type;
@@ -16,18 +17,9 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\TypeCombinator;
 
 trait GuessTypeFromSwitcherAttributes {
-	private function guessType(CallLike $call, Scope $scope) : Type
+	private function guessType(Arg $args, Scope $scope) : Type
 	{
-		$args = [];
-
-		if (isset($call->getArgs()[1]) ) {
-			$args = $call->getArgs()[1]->value;
-		}
-
-		if (empty($args)) {
-			// No arguments provided to the switcher, default type 'string'.
-			return new StringType();
-		}
+		$args = $args->value;
 
 		$isRaw = TrinaryLogic::createMaybe();
 

--- a/src/PLLModelGetLanguagesListDynamicMethodReturnTypeExtension.php
+++ b/src/PLLModelGetLanguagesListDynamicMethodReturnTypeExtension.php
@@ -74,6 +74,13 @@ class PLLModelGetLanguagesListDynamicMethodReturnTypeExtension implements Dynami
 			$argumentKeys = $argumentType->getKeysArray();
 
 			if ( $argumentKeys instanceof ConstantArrayType ) {
+				$argumentKeysTypes = $argumentKeys->getValueTypes();
+
+				if( empty( $argumentKeysTypes ) ) {
+					// An empty array is passed as parameter.
+					return new ArrayType( new IntegerType(), new ObjectType( PLL_Language::class ) );
+				}
+
 				foreach ( $argumentKeys->getValueTypes() as $index => $key ) {
 					if ( $key->getValue() !== 'fields' ) {
 						continue;

--- a/src/SwitcherClassReturnTypeExtension.php
+++ b/src/SwitcherClassReturnTypeExtension.php
@@ -9,6 +9,7 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Type;
+use PHPStan\Type\StringType;
 
 class SwitcherClassReturnTypeExtension implements DynamicMethodReturnTypeExtension {
 	use GuessTypeFromSwitcherAttributes;
@@ -25,7 +26,9 @@ class SwitcherClassReturnTypeExtension implements DynamicMethodReturnTypeExtensi
 
 	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
 	{
-		if (count($methodCall->getArgs()) === 0) {
+		$args = $methodCall->getArgs();
+
+		if (count($args) === 0) {
 			return ParametersAcceptorSelector::selectFromArgs(
 				$scope,
 				$methodCall->getArgs(),
@@ -33,6 +36,11 @@ class SwitcherClassReturnTypeExtension implements DynamicMethodReturnTypeExtensi
 			)->getReturnType();
 		}
 
-		return $this->guessType($methodCall, $scope);
+		if(isset($args[1])) {
+			return $this->guessType($args[1], $scope);
+		}
+
+		// No attributes provided to the switcher, default type 'string'.
+		return new StringType();
 	}
 }

--- a/src/TheLanguagesFunctionReturnTypeExtension.php
+++ b/src/TheLanguagesFunctionReturnTypeExtension.php
@@ -9,6 +9,7 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\Type;
+use PHPStan\Type\StringType;
 
 class TheLanguagesFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension {
 	use GuessTypeFromSwitcherAttributes;
@@ -20,14 +21,15 @@ class TheLanguagesFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $funcCall, Scope $scope): Type
 	{
-		if (count($funcCall->getArgs()) === 0) {
-			return ParametersAcceptorSelector::selectFromArgs(
-				$scope,
-				$funcCall->getArgs(),
-				$functionReflection->getVariants()
-			)->getReturnType();
+		$args = $funcCall->getArgs();
+
+		if (count($args) === 0) {
+			// No attributes provided to the switcher, default type 'string'.
+			return new StringType();
 		}
 
-		return $this->guessType($funcCall, $scope);
+		$switcherAttributes = reset($args);
+
+		return $this->guessType($switcherAttributes, $scope);
 	}
 }

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -12,9 +12,9 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
 	public function dataFileAsserts(): iterable
 	{
 		// Path to a file with actual asserts of expected types:
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/the_languages.php');
+		// yield from $this->gatherAssertTypes(__DIR__ . '/data/the_languages.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/pll_the_languages.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/get_languages_list.php');
+		// yield from $this->gatherAssertTypes(__DIR__ . '/data/get_languages_list.php');
 	}
 
 	/**

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -12,8 +12,8 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
 	public function dataFileAsserts(): iterable
 	{
 		// Path to a file with actual asserts of expected types:
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/the_languages.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/pll_the_languages.php');
+		// yield from $this->gatherAssertTypes(__DIR__ . '/data/the_languages.php');
+		// yield from $this->gatherAssertTypes(__DIR__ . '/data/pll_the_languages.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/get_languages_list.php');
 	}
 

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -12,8 +12,8 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
 	public function dataFileAsserts(): iterable
 	{
 		// Path to a file with actual asserts of expected types:
-		// yield from $this->gatherAssertTypes(__DIR__ . '/data/the_languages.php');
-		// yield from $this->gatherAssertTypes(__DIR__ . '/data/pll_the_languages.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/the_languages.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/pll_the_languages.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/get_languages_list.php');
 	}
 

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -12,9 +12,9 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
 	public function dataFileAsserts(): iterable
 	{
 		// Path to a file with actual asserts of expected types:
-		// yield from $this->gatherAssertTypes(__DIR__ . '/data/the_languages.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/the_languages.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/pll_the_languages.php');
-		// yield from $this->gatherAssertTypes(__DIR__ . '/data/get_languages_list.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/get_languages_list.php');
 	}
 
 	/**

--- a/tests/data/get_languages_list.php
+++ b/tests/data/get_languages_list.php
@@ -14,6 +14,12 @@ $array = $array;
 
 $args = ['fields' => 'slug'];
 
+// Without any argument.
+assertType('array<int, PLL_Language>', $model->get_languages_list());
+
+// With empty array.
+assertType('array<int, PLL_Language>', $model->get_languages_list([]));
+
 // With 'fields' key set explicitly.
 assertType('array<int, string>', $model->get_languages_list(['fields' => 'slug']));
 

--- a/tests/data/pll_the_languages.php
+++ b/tests/data/pll_the_languages.php
@@ -15,33 +15,33 @@ $array = $array;
 $attributes = ['foo' => 'bar'];
 
 // Raw attribute set to true.
-assertType('array<string, mixed>', pll_the_languages($link, ['raw' => true]));
+assertType('array<string, mixed>', pll_the_languages(['raw' => true]));
 
-// Raw attribute set tot true with array_merge.
-assertType('array<string, mixed>', pll_the_languages($link, array_merge($attributes, ['raw' => true])));
+// Raw attribute set to true with array_merge.
+assertType('array<string, mixed>', pll_the_languages(array_merge($attributes, ['raw' => true])));
 
 // Raw attribute set to false.
-assertType('string', pll_the_languages($link, ['raw' => false]));
+assertType('string', pll_the_languages(['raw' => false]));
 
 // Raw attribute set tot false with array_merge.
-assertType('string', pll_the_languages($link, array_merge($attributes, ['raw' => false])));
+assertType('array<string, mixed>|string', pll_the_languages(array_merge($attributes, ['raw' => false])));
 
 // Without raw set.
-assertType('string', pll_the_languages($link, $attributes));
+assertType('string', pll_the_languages($attributes));
 
 // With empty array.
-assertType('string', pll_the_languages($link, []));
+assertType('string', pll_the_languages([]));
 
 // Default attributes.
-assertType('string', pll_the_languages($link));
+assertType('string', pll_the_languages());
 
 // Unkown attributes.
-assertType('array<string, mixed>|string', pll_the_languages($link, $array));
+assertType('array<string, mixed>|string', pll_the_languages($array));
 
 // With unkown variable merged.
 $args = array_merge( array( 'raw' => 1 ), $options );
-assertType('array<string, mixed>|string', pll_the_languages($link, $args));
+assertType('array<string, mixed>|string', pll_the_languages($args));
 
 // With raw attribute set to true outside.
 $array['raw'] = 1;
-assertType('array<string, mixed>', pll_the_languages($link, $array));
+assertType('array<string, mixed>', pll_the_languages($array));

--- a/tests/data/pll_the_languages.php
+++ b/tests/data/pll_the_languages.php
@@ -23,8 +23,8 @@ assertType('array<string, mixed>', pll_the_languages(array_merge($attributes, ['
 // Raw attribute set to false.
 assertType('string', pll_the_languages(['raw' => false]));
 
-// Raw attribute set tot false with array_merge.
-assertType('array<string, mixed>|string', pll_the_languages(array_merge($attributes, ['raw' => false])));
+// Raw attribute set to false with array_merge and variable with known values.
+assertType('string', pll_the_languages(array_merge($attributes, ['raw' => false])));
 
 // Without raw set.
 assertType('string', pll_the_languages($attributes));


### PR DESCRIPTION
`pll_the_languages()` wasn't tested correctly, so returned types weren't always right...

## Changes
- Call `pll_the_languages()` with only one parameter.
- Return string type if no array of attributes is passed (both for method and function).
- `guessType()` now accept `PhpParser\Node\Arg` since we check values before calling it.
- Return `PLL_String[]` if an empty array is passed to `get_languages_list()`.