### PR TITLE
Add dynamic return type extension for `Options::get()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"type": "library",
 	"require": {
 		"szepeviktor/phpstan-wordpress": "^1.0",
-		"wpsyntex/polylang-stubs": "*"
+		"wpsyntex/polylang-stubs": "dev-options-as-objects-main"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^7 || ^9"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"type": "library",
 	"require": {
 		"szepeviktor/phpstan-wordpress": "^1.0",
-		"wpsyntex/polylang-stubs": "dev-options-as-objects-main"
+		"wpsyntex/polylang-stubs": "dev-master"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^7 || ^9"

--- a/extension.neon
+++ b/extension.neon
@@ -15,6 +15,10 @@ services:
 		class: WPSyntex\Polylang\PHPStan\PLLModelGetLanguagesListDynamicMethodReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: WPSyntex\Polylang\PHPStan\OptionsGetDynamicMethodReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
 includes:
 	- ../../szepeviktor/phpstan-wordpress/extension.neon
 parameters:

--- a/src/LanguageReturnTypeExtension.php
+++ b/src/LanguageReturnTypeExtension.php
@@ -13,7 +13,7 @@ use PHPStan\Type\TypeCombinator;
 
 class LanguageReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension {
 	public function isFunctionSupported( FunctionReflection $functionReflection ) : bool {
-		return in_array( $functionReflection->getName(), array( 'pll_current_language', 'pll_default_language' ), true );
+		return in_array( $functionReflection->getName(), [ 'pll_current_language', 'pll_default_language' ], true );
 	}
 
 	public function getTypeFromFunctionCall( FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope ) : Type {

--- a/src/OptionsGetDynamicMethodReturnTypeExtension.php
+++ b/src/OptionsGetDynamicMethodReturnTypeExtension.php
@@ -129,7 +129,7 @@ class OptionsGetDynamicMethodReturnTypeExtension implements DynamicMethodReturnT
 	 * @return Type
 	 */
 	protected function getDefaultReturnType( string $option_name ): Type {
-		if ( ! defined( 'POLYLANG_PRO' ) || ! POLYLANG_PRO ) {
+		if ( ! defined( 'POLYLANG_PRO_PHPSTAN' ) || ! POLYLANG_PRO_PHPSTAN ) { // Constant specific to PHPStan in Polylang Pro.
 			return new NullType();
 		}
 

--- a/src/OptionsGetDynamicMethodReturnTypeExtension.php
+++ b/src/OptionsGetDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Dynamic return type for `WP_Syntex\Polylang\Options\Options->get()`.
+ */
+
+declare(strict_types=1);
+
+namespace WPSyntex\Polylang\PHPStan;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+class OptionsGetDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension {
+	public function getClass(): string {
+		return \WP_Syntex\Polylang\Options\Options::class;
+	}
+
+	public function isMethodSupported( MethodReflection $methodReflection ): bool {
+		return in_array( $methodReflection->getName(), array( 'get', 'reset', 'offsetGet' ), true );
+	}
+
+	public function getTypeFromMethodCall( MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope ): ?Type {
+		if ( count( $methodCall->getArgs() ) === 0 ) {
+			return null;
+		}
+
+		$argumentType = $scope->getType( $methodCall->getArgs()[0]->value );
+
+		// When called with a type that isn't a constant string, return default return type.
+		if ( count( $argumentType->getConstantStrings() ) === 0 ) {
+			return null;
+		}
+
+		// Called with a constant string type.
+		$returnType = array();
+
+		foreach ( $argumentType->getConstantStrings() as $constantString ) {
+			switch ( $constantString->getValue() ) {
+				case 'browser':
+				case 'hide_default':
+				case 'media_support':
+				case 'redirect_lang':
+				case 'rewrite':
+					$returnType[] = new BooleanType();
+					break;
+
+				case 'default_lang':
+				case 'previous_version':
+				case 'version':
+					$returnType[] = new StringType();
+					break;
+
+				case 'domains':
+					$returnType[] = new ArrayType(
+						$this->getNonFalsyStringType(),
+						new StringType()
+					);
+					break;
+
+				case 'language_taxonomies':
+				case 'post_types':
+				case 'sync':
+				case 'taxonomies':
+					$returnType[] = AccessoryArrayListType::intersectWith(
+						new ArrayType(
+							new IntegerType(),
+							$this->getNonFalsyStringType()
+						)
+					);
+					break;
+
+				case 'nav_menus':
+					$returnType[] = new ArrayType(
+						$this->getNonFalsyStringType(),
+						new ArrayType(
+							$this->getNonFalsyStringType(),
+							new ArrayType(
+								$this->getNonFalsyStringType(),
+								IntegerRangeType::fromInterval( 0, \PHP_INT_MAX )
+							)
+						)
+					);
+					break;
+
+				case 'first_activation':
+					$returnType[] = IntegerRangeType::fromInterval( 0, \PHP_INT_MAX );
+					break;
+
+				case 'force_lang':
+					$returnType[] = IntegerRangeType::fromInterval( 0, 3 );
+					break;
+
+				default:
+					$returnType[] = $this->getDefaultReturnType( $constantString->getValue() );
+			}
+		}
+
+		return TypeCombinator::union( ...$returnType );
+	}
+
+	protected function getNonFalsyStringType(): Type {
+		return new IntersectionType(
+			array(
+				new StringType(),
+				new AccessoryNonFalsyStringType(),
+			)
+		);
+	}
+
+	/**
+	 * Returns the type to return (!) when the option name is unknown.
+	 * Currently handles Polylang Pro's options.
+	 * Can be overwritten to handle more option names.
+	 *
+	 * @param string $option_name Option name.
+	 * @return Type
+	 */
+	protected function getDefaultReturnType( string $option_name ): Type {
+		if ( ! defined( 'POLYLANG_PRO' ) || ! POLYLANG_PRO ) {
+			return new NullType();
+		}
+
+		switch ( $option_name ) {
+			case 'media':
+				return new ArrayType(
+					$this->getNonFalsyStringType(),
+					new BooleanType()
+				);
+
+			case 'machine_translation_enabled':
+				return new BooleanType();
+
+			case 'machine_translation_services':
+				return new ArrayType(
+					$this->getNonFalsyStringType(),
+					new ArrayType(
+						$this->getNonFalsyStringType(),
+						new StringType()
+					)
+				);
+
+			default:
+				return new NullType();
+		}
+	}
+}

--- a/src/OptionsGetDynamicMethodReturnTypeExtension.php
+++ b/src/OptionsGetDynamicMethodReturnTypeExtension.php
@@ -29,7 +29,7 @@ class OptionsGetDynamicMethodReturnTypeExtension implements DynamicMethodReturnT
 	}
 
 	public function isMethodSupported( MethodReflection $methodReflection ): bool {
-		return in_array( $methodReflection->getName(), array( 'get', 'reset', 'offsetGet' ), true );
+		return in_array( $methodReflection->getName(), [ 'get', 'reset', 'offsetGet' ], true );
 	}
 
 	public function getTypeFromMethodCall( MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope ): ?Type {
@@ -45,7 +45,7 @@ class OptionsGetDynamicMethodReturnTypeExtension implements DynamicMethodReturnT
 		}
 
 		// Called with a constant string type.
-		$returnType = array();
+		$returnType = [];
 
 		foreach ( $argumentType->getConstantStrings() as $constantString ) {
 			switch ( $constantString->getValue() ) {
@@ -113,10 +113,10 @@ class OptionsGetDynamicMethodReturnTypeExtension implements DynamicMethodReturnT
 
 	protected function getNonFalsyStringType(): Type {
 		return new IntersectionType(
-			array(
+			[
 				new StringType(),
 				new AccessoryNonFalsyStringType(),
-			)
+			]
 		);
 	}
 

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -15,6 +15,7 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/the_languages.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/pll_the_languages.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/get_languages_list.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/options_get.php');
 	}
 
 	/**

--- a/tests/data/get_languages_list.php
+++ b/tests/data/get_languages_list.php
@@ -26,12 +26,12 @@ assertType('array<int, string>', $model->get_languages_list(['fields' => 'slug']
 // With 'fields' key set in a variable.
 assertType('array<int, string>', $model->get_languages_list($args));
 
-// With a variable containing unkown data.
+// With a variable containing unknown data.
 assertType('array<int, mixed>', $model->get_languages_list($array));
 
 // With array_merge() result passed as parameter.
 assertType('array<int, mixed>', $model->get_languages_list(array_merge($array, ['fields' => 'slug'])));
 
-// With 'fields' key set on top of variable containing unkown data.
+// With 'fields' key set on top of variable containing unknown data.
 $array['fields'] = 'slug';
 assertType('array<int, string>', $model->get_languages_list($array));

--- a/tests/data/options_get.php
+++ b/tests/data/options_get.php
@@ -16,12 +16,12 @@ assertType('null', $options->get('foo'));
 assertType('null', $options->get('media'));
 
 // With a boolean type option.
-foreach ( array( 'browser', 'hide_default', 'media_support', 'redirect_lang', 'rewrite' ) as $option_name ) {
+foreach ( [ 'browser', 'hide_default', 'media_support', 'redirect_lang', 'rewrite' ] as $option_name ) {
 	assertType('bool', $options->get($option_name));
 }
 
 // With a string type option.
-foreach ( array( 'default_lang', 'previous_version', 'version' ) as $option_name ) {
+foreach ( [ 'default_lang', 'previous_version', 'version' ] as $option_name ) {
 	assertType('string', $options->get($option_name));
 }
 
@@ -29,7 +29,7 @@ foreach ( array( 'default_lang', 'previous_version', 'version' ) as $option_name
 assertType('array<non-falsy-string, string>', $options->get('domains'));
 
 // With a list type option.
-foreach ( array( 'language_taxonomies', 'post_types', 'sync', 'taxonomies' ) as $option_name ) {
+foreach ( [ 'language_taxonomies', 'post_types', 'sync', 'taxonomies' ] as $option_name ) {
 	assertType('array<int, non-falsy-string>', $options->get($option_name));
 }
 

--- a/tests/data/options_get.php
+++ b/tests/data/options_get.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPSyntex\Polylang\PHPStan\Tests;
+
+use function PHPStan\Testing\assertType;
+
+/** @var \WP_Syntex\Polylang\Options\Options */
+$options = $options;
+
+// With an unknown option.
+assertType('null', $options->get('foo'));
+
+// With a Pro option in PLL Free.
+assertType('null', $options->get('media'));
+
+// With a boolean type option.
+foreach ( array( 'browser', 'hide_default', 'media_support', 'redirect_lang', 'rewrite' ) as $option_name ) {
+	assertType('bool', $options->get($option_name));
+}
+
+// With a string type option.
+foreach ( array( 'default_lang', 'previous_version', 'version' ) as $option_name ) {
+	assertType('string', $options->get($option_name));
+}
+
+// Domains.
+assertType('array<non-falsy-string, string>', $options->get('domains'));
+
+// With a list type option.
+foreach ( array( 'language_taxonomies', 'post_types', 'sync', 'taxonomies' ) as $option_name ) {
+	assertType('array<int, non-falsy-string>', $options->get($option_name));
+}
+
+// With the nav menus option.
+assertType('array<non-falsy-string, array<non-falsy-string, array<non-falsy-string, int<0, 9223372036854775807>>>>', $options->get('nav_menus'));
+
+// With the first activation option.
+assertType('int<0, 9223372036854775807>', $options->get('first_activation'));
+
+// With the force lang option.
+assertType('int<0, 3>', $options->get('force_lang'));
+
+//define( 'POLYLANG_PRO', true );
+
+// With a Pro option in PLL Pro.
+//assertType('array<non-falsy-string, bool>', $options->get('media'));

--- a/tests/data/pll_the_languages.php
+++ b/tests/data/pll_the_languages.php
@@ -35,10 +35,10 @@ assertType('string', pll_the_languages([]));
 // Default attributes.
 assertType('string', pll_the_languages());
 
-// Unkown attributes.
+// Unknown attributes.
 assertType('array<string, mixed>|string', pll_the_languages($array));
 
-// With unkown variable merged.
+// With unknown variable merged.
 $args = array_merge( array( 'raw' => 1 ), $options );
 assertType('array<string, mixed>|string', pll_the_languages($args));
 

--- a/tests/data/pll_the_languages.php
+++ b/tests/data/pll_the_languages.php
@@ -39,7 +39,7 @@ assertType('string', pll_the_languages());
 assertType('array<string, mixed>|string', pll_the_languages($array));
 
 // With unknown variable merged.
-$args = array_merge( array( 'raw' => 1 ), $options );
+$args = array_merge( [ 'raw' => 1 ], $options );
 assertType('array<string, mixed>|string', pll_the_languages($args));
 
 // With raw attribute set to true outside.

--- a/tests/data/the_languages.php
+++ b/tests/data/the_languages.php
@@ -42,7 +42,7 @@ assertType('string', $switcher->the_languages($link));
 assertType('array<string, mixed>|string', $switcher->the_languages($link, $array));
 
 // With unknown variable merged.
-$args = array_merge( $array, array( 'raw' => 1 ) );
+$args = array_merge( $array, [ 'raw' => 1 ] );
 assertType('array<string, mixed>|string', $switcher->the_languages($link, $args));
 
 // With raw attribute set to true outside.

--- a/tests/data/the_languages.php
+++ b/tests/data/the_languages.php
@@ -38,10 +38,10 @@ assertType('string', $switcher->the_languages($link, []));
 // Default attributes.
 assertType('string', $switcher->the_languages($link));
 
-// Unkown attributes.
+// Unknown attributes.
 assertType('array<string, mixed>|string', $switcher->the_languages($link, $array));
 
-// With unkown variable merged.
+// With unknown variable merged.
 $args = array_merge( $array, array( 'raw' => 1 ) );
 assertType('array<string, mixed>|string', $switcher->the_languages($link, $args));
 


### PR DESCRIPTION
This adds a dynamic return type extension for the methods `get()`, `reset()`, and `offsetGet()` from the class `WP_Syntex\Polylang\Options\Options`.
Unit tests have been added.
This also fixes a couple of typos.

> [!WARNING]
> Restore `composer.json` before merging.