### PR TITLE
Remove the dependency to `polylang-stubs`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
 	"homepage": "https://polylang.pro",
 	"type": "library",
 	"require": {
-		"szepeviktor/phpstan-wordpress": "^1.0",
-		"wpsyntex/polylang-stubs": "dev-master"
+		"szepeviktor/phpstan-wordpress": "^1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^7 || ^9"


### PR DESCRIPTION
This dependency is not needed in PLL nor PLL Pro, and causes issues with code editors.

Our packages that use `polylang-phpstan` without requiring `polylang-stubs` explicitly (except PLL and PLL Pro).
- PLL WC: [PR](https://github.com/polylang/polylang-wc/pull/880).
- PLL DI: not needed.
- PLL Updater: [PR](https://github.com/polylang/updater/pull/8).
- PLL Actions: doesn't require it but [removes it](https://github.com/polylang/actions/blob/36164c6e2dcb289a092e71c2dd5332191920defe/phpunit/action.yml#L46).
- Dynamo: not needed.