### PR TITLE
Create extension for `Model\Languages::get_list()`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -16,7 +16,7 @@ services:
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
-		class: WPSyntex\Polylang\PHPStan\PLLModelLanguagesGetListDynamicMethodReturnTypeExtension
+		class: WPSyntex\Polylang\PHPStan\ModelLanguagesGetListDynamicMethodReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-

--- a/src/ModelLanguagesGetListDynamicMethodReturnTypeExtension.php
+++ b/src/ModelLanguagesGetListDynamicMethodReturnTypeExtension.php
@@ -26,7 +26,7 @@ use PHPStan\Type\UnionType;
 use PLL_Language;
 use WP_Syntex\Polylang\Model\Languages;
 
-class PLLModelLanguagesGetListDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension {
+class ModelLanguagesGetListDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension {
 	public function getClass(): string {
 		return Languages::class;
 	}

--- a/src/PLLModelGetLanguagesListDynamicMethodReturnTypeExtension.php
+++ b/src/PLLModelGetLanguagesListDynamicMethodReturnTypeExtension.php
@@ -11,7 +11,7 @@ namespace WPSyntex\Polylang\PHPStan;
 use PLL_Model;
 use PHPStan\Reflection\MethodReflection;
 
-class PLLModelGetLanguagesListDynamicMethodReturnTypeExtension extends PLLModelLanguagesGetListDynamicMethodReturnTypeExtension {
+class PLLModelGetLanguagesListDynamicMethodReturnTypeExtension extends ModelLanguagesGetListDynamicMethodReturnTypeExtension {
 	public function getClass(): string {
 		return PLL_Model::class;
 	}


### PR DESCRIPTION
Closes #13.

Use the same extension than the one for `PLL_Model::get_languages_list()`.