### PR TITLE
Move `wpsyntex/polylang-stubs` to dev dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Include the extension and stubs in the PHPStan configuration file.
 includes:
   - vendor/wpsyntex/polylang-phpstan/extension.neon
 parameters:
-  stubFiles:
+  scanFiles:
     - vendor/wpsyntex/polylang-stubs/polylang-stubs.php
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
 	"type": "library",
 	"require": {
 		"php": "^8.0",
-		"szepeviktor/phpstan-wordpress": "^2.0",
-		"wpsyntex/polylang-stubs": "dev-master"
+		"szepeviktor/phpstan-wordpress": "^2.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^9"
+		"phpunit/phpunit": "^9",
+		"wpsyntex/polylang-stubs": "dev-master"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
## What?
All in the title.

## Why?
Prevent consuming packages to have `wpsyntex/polylang-stubs` in their vendors when not needed.

## How?
- update `composer.json`
- take the opportunity to fix doc in README (imprecision in the PHPStan configuration)